### PR TITLE
Adds command: pod reinstall

### DIFF
--- a/lib/cocoapods_plugin.rb
+++ b/lib/cocoapods_plugin.rb
@@ -1,1 +1,2 @@
 require 'pod/command/open'
+require 'pod/command/reinstall'

--- a/lib/pod/command/reinstall.rb
+++ b/lib/pod/command/reinstall.rb
@@ -1,0 +1,24 @@
+module Pod
+  class Command
+    class Reinstall < Command
+
+      self.summary = 'Run pod install and then open the workspace'
+      self.description = <<-DESC
+         Runs pod install before trying to reopen the workspace with pod open.
+      DESC
+
+      def initialize(argv)
+        super
+      end
+
+      def validate!
+        super
+      end
+
+      def run
+        `pod install && pod open`
+      end
+
+    end
+  end
+end

--- a/lib/pod/command/reinstall.rb
+++ b/lib/pod/command/reinstall.rb
@@ -2,9 +2,9 @@ module Pod
   class Command
     class Reinstall < Command
 
-      self.summary = 'Run pod install and then open the workspace'
+      self.summary = 'Install dependencies and then re-open the workspace'
       self.description = <<-DESC
-         Runs pod install before trying to reopen the workspace with pod open.
+         Runs 'pod install' before trying to reopen the workspace with 'pod open'.
       DESC
 
       def initialize(argv)
@@ -16,7 +16,17 @@ module Pod
       end
 
       def run
-        `pod install && pod open`
+        # Output the results of pod install in realtime
+        # http://stackoverflow.com/questions/10224481/running-a-command-from-ruby-displaying-and-capturing-the-output
+        output = []
+        r, io = IO.pipe
+        fork do
+          system("pod install", out: io, err: :out)
+        end
+        io.close
+        r.each_line{|l| puts l; output << l.chomp}
+
+        `pod open`
       end
 
     end


### PR DESCRIPTION
This command will run `pod install` and output the results of the command in realtime and then run `pod open`.

Thought it was a good companion to `pod open` since I find myself often closing xcode, adjusting the Podfile, and then running `pod install && pod open`.
