### PR TITLE
Open in AppCode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,13 @@ Install the gem:
 
 ## Usage
 
-Open the workspace
+Open the workspace in Xcode
 
     pod open
+
+Open the workspace in AppCode
+
+    pod open -a
 
 Install pods and then open the workspace (`pod install && pod open`)
 


### PR DESCRIPTION
`pod open -a` opens workspace in AppCode.

```
➜  bundle exec pod open --help
Usage:

    $ pod open [-a]

      Opens the workspace in xcode. If no workspace found in the current directory,
      looks up until it finds one. Pass `-a` flag if you want to open in AppCode.

Options:

    --silent     Show nothing
    --version    Show the version of CocoaPods
    --no-color   Show output without color
    --verbose    Show more debugging information
    --help       Show help banner of specified command
```

Would be nice to add `-a` option to 'Options' section but I didn't get how to do this :( Suggestions and recommendations are welcome ;)
