### PR TITLE
Use option syntax for '-a'.

### DIFF
--- a/lib/pod/command/open.rb
+++ b/lib/pod/command/open.rb
@@ -5,9 +5,14 @@ module Pod
       self.summary = 'Open the workspace'
       self.description = <<-DESC
         Opens the workspace in xcode. If no workspace found in the current directory,
-        looks up until it finds one. Pass `-a` flag if you want to open in AppCode.
+        looks up until it finds one.
       DESC
-      self.arguments = [['-a', :optional]]
+
+      def self.options
+        [
+          ['-a',     'Open in AppCode.']
+        ]
+      end
 
       def initialize(argv)
         @use_appcode = (argv.shift_argument == '-a')


### PR DESCRIPTION
Fixes a warning with newer versions of CLAide.
